### PR TITLE
Feature/#5 add share target picker and  external browser support

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -12,6 +12,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@line/bot-sdk": "^7.5.2",
     "@types/react": "18.2.15",
     "@types/react-dom": "18.2.7",
     "@vitejs/plugin-react": "4.0.3",

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,41 +1,82 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import liff from "@line/liff";
 import "./App.css";
 
 function App() {
-  const [message, setMessage] = useState("");
-  const [error, setError] = useState("");
-
-  useEffect(() => {
-    liff
-      .init({
-        liffId: import.meta.env.VITE_LIFF_ID
-      })
-      .then(() => {
-        setMessage("LIFF init succeeded.");
-      })
-      .catch((e: Error) => {
-        setMessage("LIFF init failed.");
-        setError(`${e}`);
-      });
+  const [formData, setFormData] = useState({
+    date: "",
+    location: "",
+    details: "",
   });
 
+  const handleChange = (e: any) => {
+    const { name, value } = e.target;
+    setFormData((prevData) => ({ ...prevData, [name]: value }));
+  };
+
+  const onClickShare = () => {
+    if (liff.isApiAvailable("shareTargetPicker")) {
+      const message: { type: "text"; text: string } = {
+        type: "text",
+        text: `イベントの詳細:\n日時: ${formData.date}\n場所: ${formData.location}\n詳細: ${formData.details} \n\n LIFF勉強会情報アカウント を友だち追加できます\nhttps://lin.ee/xoM6MwD`,
+      };
+
+      liff
+        .shareTargetPicker([message])
+        .catch(() => {
+          alert(ERROR_MESSAGE.SHARE_TARGET_PICKER);
+        })
+        .finally(() => {
+          liff.closeWindow();
+        });
+    } else {
+      alert(ERROR_MESSAGE.DEVICE_NOT_SUPPORTED);
+    }
+  };
+
+  const ERROR_MESSAGE = {
+    SHARE_TARGET_PICKER:
+      "シェアターゲットピッカーの起動に失敗しました。少し時間をおいてから再度お試しください。",
+    DEVICE_NOT_SUPPORTED:
+      "申し訳ありませんが、このデバイスでは「シェアターゲットピッカー」が利用できません。他の方法で共有をお試しください。",
+  };
+
   return (
-    <div className="App">
-      <h1>create-liff-app</h1>
-      {message && <p>{message}</p>}
-      {error && (
-        <p>
-          <code>{error}</code>
-        </p>
-      )}
-      <a
-        href="https://developers.line.biz/ja/docs/liff/"
-        target="_blank"
-        rel="noreferrer"
-      >
-        LIFF Documentation
-      </a>
+    <div>
+      <h2>イベント招待</h2>
+      <div>
+        <label>
+          日時:
+          <input
+            type="datetime-local"
+            name="date"
+            value={formData.date}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          場所:
+          <input
+            type="text"
+            name="location"
+            value={formData.location}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          詳細:
+          <textarea
+            name="details"
+            value={formData.details}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <button onClick={onClickShare}>イベントを友達にシェアする</button>
     </div>
   );
 }

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { ChangeEventHandler, useState } from "react";
 import liff from "@line/liff";
 import "./App.css";
 
@@ -9,7 +9,9 @@ function App() {
     details: "",
   });
 
-  const handleChange = (e: any) => {
+  const handleChange: ChangeEventHandler<
+    HTMLInputElement | HTMLTextAreaElement
+  > = (e) => {
     const { name, value } = e.target;
     setFormData((prevData) => ({ ...prevData, [name]: value }));
   };

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -6,7 +6,7 @@ function App() {
   const [formData, setFormData] = useState({
     date: "",
     location: "",
-    details: "",
+    detail: "",
   });
 
   const handleChange: ChangeEventHandler<
@@ -20,7 +20,7 @@ function App() {
     if (liff.isApiAvailable("shareTargetPicker")) {
       const message: { type: "text"; text: string } = {
         type: "text",
-        text: `イベントの詳細:\n日時: ${formData.date}\n場所: ${formData.location}\n詳細: ${formData.details} \n\n LIFF勉強会情報アカウント を友だち追加できます\nhttps://lin.ee/xoM6MwD`,
+        text: `イベントの詳細:\n日時: ${formData.date}\n場所: ${formData.location}\n詳細: ${formData.detail} \n\n LIFF勉強会情報アカウント を友だち追加できます\nhttps://lin.ee/xoM6MwD`,
       };
 
       liff
@@ -72,8 +72,8 @@ function App() {
         <label>
           詳細:
           <textarea
-            name="details"
-            value={formData.details}
+            name="detail"
+            value={formData.detail}
             onChange={handleChange}
           />
         </label>

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,6 +1,7 @@
 import { ChangeEventHandler, useState } from "react";
 import liff from "@line/liff";
 import "./App.css";
+import type { TextMessage } from "@line/bot-sdk";
 
 function App() {
   const [formData, setFormData] = useState({
@@ -18,7 +19,7 @@ function App() {
 
   const onClickShare = () => {
     if (liff.isApiAvailable("shareTargetPicker")) {
-      const message: { type: "text"; text: string } = {
+      const message: TextMessage = {
         type: "text",
         text: `イベントの詳細:\n日時: ${formData.date}\n場所: ${formData.location}\n詳細: ${formData.detail} \n\n LIFF勉強会情報アカウント を友だち追加できます\nhttps://lin.ee/xoM6MwD`,
       };

--- a/front/src/main.tsx
+++ b/front/src/main.tsx
@@ -4,7 +4,7 @@ import liff from "@line/liff";
 
 const initializeLiff = async () => {
   await liff.init({ liffId: import.meta.env.VITE_LIFF_ID || "" });
-  // 外部ブラウザ対応　外部ブラウザで開いた場合は、ログインを促す
+  // 外部ブラウザ対応 外部ブラウザで開いた場合は、ログインを促す
   if (!liff.isLoggedIn()) {
     liff.login();
   }

--- a/front/src/main.tsx
+++ b/front/src/main.tsx
@@ -1,10 +1,28 @@
-import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import App from "./App";
+import liff from "@line/liff";
 
-ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById("root")
-);
+const initializeLiff = async () => {
+  await liff.init({ liffId: import.meta.env.VITE_LIFF_ID || "" });
+  // 外部ブラウザ対応　外部ブラウザで開いた場合は、ログインを促す
+  if (!liff.isLoggedIn()) {
+    liff.login();
+  }
+};
+
+const renderApp = () => {
+  const container = document.getElementById("root");
+  if (container) {
+    const root = createRoot(container);
+    root.render(<App />);
+  }
+};
+
+(async () => {
+  try {
+    await initializeLiff();
+    renderApp();
+  } catch (e: any) {
+    alert(`LIFF error: ${e.message}`);
+  }
+})();

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -826,7 +826,7 @@
     "@liff/logger" "2.22.2"
     "@liff/util" "2.22.2"
 
-"@line/bot-sdk@^7.0.0":
+"@line/bot-sdk@^7.0.0", "@line/bot-sdk@^7.5.2":
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/@line/bot-sdk/-/bot-sdk-7.5.2.tgz#ecf5410e2ceda0ed491aa178c587be8f2b691ddd"
   integrity sha512-mMaDnr+mOqQDLYJcUp+fQwZklg/LoOZzNILlWdsj2IFD2nXF+HhAm3KEy5tyUx629Y2bCx6nv9Jl0UlMwBiAiw==


### PR DESCRIPTION
# PR 概要

- サンプル用のMessagingAPIチャネルのリッチメニューからサンプルLIFFを開けるようにしました。
   - まだホスティングしていないので、リッチメニューのリンクのURLはサンプル用のLINEログインチャネルのLIFFの髙原開発用のLIFFURLが設定してあります。（自分用のngrokのURLがエンドポイントに設定してあります。）
- 外部ブラウザ対応を追加しました。
- liff.initをmain.tsx内で行うように修正しました。
- shareTargetPickerでのサンプル処理を追加してみました。

## 関連 ISSUE

<!-- close #1-->
close #3  
close #5


## その他

- 一旦、shareTargetPickerのサンプルとして、ユーザーがイベントの詳細を入力し、それを友達と簡単に共有できるという設定で作成してみました。 

https://github.com/Takaharayuuki/LINEDC_LIFF_study/assets/54837280/b20c4434-3f1d-408c-a40e-49dd53f3a259

